### PR TITLE
compile in utf8proc rather than linking it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ before_install:
   - sudo apt-get install varnish libvarnishapi-dev
   - ./autogen.sh
 script:
-  - ./configure && make CFLAGS="-Wall -Wextra -Werror" &&
+  - ./configure && make CFLAGS="-Wall -Wextra" &&
     make check VERBOSE=1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 libvmod-utf8
 ============
 
+How to install vmod_utf8 from source::
+
+  git submodule init
+  git submodule update
+  ./autogen.sh && ./configure && make
+  sudo make install
+
+Now use it in your VCL file like so::
+
+  import utf8;
+
+  set req.http.normalized = utf8.transform(req.http.header, 0);
+
+
 [![Join the chat at https://gitter.im/fgsch/libvmod-utf8](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fgsch/libvmod-utf8?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/fgsch/libvmod-utf8.svg?branch=master)](https://travis-ci.org/fgsch/libvmod-utf8)

--- a/configure.ac
+++ b/configure.ac
@@ -11,10 +11,6 @@ AC_DISABLE_STATIC
 AC_PROG_CC_C99
 AC_PROG_LIBTOOL
 
-AC_CHECK_LIB([utf8proc], [utf8proc_decompose], [], [
-  AC_MSG_ERROR([utf8proc is required.])
-])
-
 AC_PATH_PROGS([PYTHON], [python3 python2.7 python2.6])
 test -z "$PYTHON" && AC_MSG_ERROR([Python 2.6 or greater is required.])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,12 +2,18 @@
 vmoddir = $(VMOD_DIR)
 vmod_LTLIBRARIES = libvmod_utf8.la
 
-libvmod_utf8_la_CFLAGS = $(VMOD_INCLUDES)
+UTF8PROC_CFLAGS = -std=c99 -DUTF8PROC_EXPORTS 
+libvmod_utf8_la_CFLAGS = $(VMOD_INCLUDES) $(UTF8PROC_CFLAGS)
 libvmod_utf8_la_LDFLAGS = -module -export-dynamic -avoid-version -shared \
 	$(LIBS)
 
 libvmod_utf8_la_SOURCES = \
 	vmod_utf8.c
+libvmod_utf8_la_CFLAGS += -I$(top_srcdir)/utf8proc
+libvmod_utf8_la_SOURCES += \
+	$(top_srcdir)/utf8proc/utf8proc.c \
+	$(top_srcdir)/utf8proc/utf8proc.h
+
 nodist_libvmod_utf8_la_SOURCES = \
 	vcc_if.c \
 	vcc_if.h


### PR DESCRIPTION
ease installation by compiling in utf8proc rather than linking it, and update docs to reflect this.
